### PR TITLE
Convert from LiTHe Kod to LiTHe kod

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# LitheKod
-Prototype site for LitheKod organisation at LiU
+# LiTHe kod
+Prototype site for LiTHe kod organisation at LiU

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <script async type="text/javascript" src="js/min/modernizr-min.js"></script>
     <link rel="stylesheet" href="css/reset.css">
     <link rel="stylesheet" href="css/style.css">
-    <title>LitheKod</title>
+    <title>LiTHe kod</title>
 </head>
 
 <body>
@@ -95,7 +95,7 @@
                 Verksamhetsgrupp
             </h2>
             <p>
-                LiTHe Kods verksamhetsgrupp anordnar alla kodstugor, tävlingar och event. Verksamhetsgruppen består av ett tiotal glada studenter som hjälper till med olika delar av LiTHe Kods verksamhet.
+                LiTHe kods verksamhetsgrupp anordnar alla kodstugor, tävlingar och event. Verksamhetsgruppen består av ett tiotal glada studenter som hjälper till med olika delar av LiTHe kods verksamhet.
             </p>
             <h4>
                 Vill du vara med?
@@ -147,7 +147,7 @@
                 Postadress
             </h4>
             <p>
-                LiTHe Kod Kårallen, Universitetet 581 83 Linköping
+                LiTHe kod Kårallen, Universitetet 581 83 Linköping
             </p>
         </div>
     </section>


### PR DESCRIPTION
Convert the captilisation of every variation of LiTHe kod to the
correct one; LiTHe kod with a small 'k' in "kod".

The assocation is called LiTHe kod, note the capitalisation on "kod"
which follows Swedish language rules.
